### PR TITLE
feat: add private chat windows

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -2,6 +2,7 @@
 const socket = io();
 let currentUser = null;
 let users = [];
+const privateChats = new Map();
 
 const $ = (sel) => document.querySelector(sel);
 const $$ = (sel) => Array.from(document.querySelectorAll(sel));
@@ -45,13 +46,56 @@ function renderUsers(list) {
     li.textContent = u.name + (currentUser && u.id === currentUser.id ? ' (you)' : '');
     li.dataset.id = u.id;
     if (!currentUser || u.id !== currentUser.id) {
-      li.onclick = () => {
-        const text = prompt(`Private message to ${u.name}:`);
-        if (text) socket.emit('private_message', { to: u.id, text });
-      };
+      li.onclick = () => openPrivateChat(u);
     }
     userList.appendChild(li);
   });
+}
+
+function openPrivateChat(user) {
+  if (privateChats.has(user.id)) return;
+  const container = document.getElementById('privateChats');
+  const chat = document.createElement('div');
+  chat.className = 'private-chat';
+  chat.dataset.id = user.id;
+  chat.innerHTML = `
+    <div class="header">
+      <span class="title">${escapeHtml(user.name)}</span>
+      <button class="close">&times;</button>
+    </div>
+    <div class="messages"></div>
+    <div class="composer">
+      <input class="pm-input" placeholder="Message ${escapeHtml(user.name)}" />
+      <button class="pm-send">Send</button>
+    </div>
+  `;
+  container.appendChild(chat);
+
+  const input = chat.querySelector('.pm-input');
+  const sendBtn = chat.querySelector('.pm-send');
+  chat.querySelector('.close').onclick = () => {
+    chat.remove();
+    privateChats.delete(user.id);
+  };
+  sendBtn.onclick = () => {
+    const text = input.value.trim();
+    if (!text) return;
+    socket.emit('private_message', { to: user.id, text });
+    input.value = '';
+  };
+  input.addEventListener('keypress', e => {
+    if (e.key === 'Enter') sendBtn.click();
+  });
+  privateChats.set(user.id, chat);
+  input.focus();
+}
+
+function closePrivateChat(userId) {
+  const chat = privateChats.get(userId);
+  if (chat) {
+    chat.remove();
+    privateChats.delete(userId);
+  }
 }
 
 function renderPoll(poll) {
@@ -150,6 +194,7 @@ socket.on('user_left', (user) => {
   addSystem(`${user.name} left.`);
   users = users.filter(u => u.id !== user.id);
   renderUsers(users);
+  closePrivateChat(user.id);
 });
 
 socket.on('message_new', addMessage);
@@ -167,16 +212,21 @@ function addSystem(text) {
 }
 
 function addPrivateMessage({ from, to, text, ts }) {
+  const other = currentUser && from.id === currentUser.id ? to : from;
+  if (!privateChats.has(other.id)) {
+    openPrivateChat(other);
+  }
+  const chat = privateChats.get(other.id);
+  const list = chat.querySelector('.messages');
   const div = document.createElement('div');
-  div.className = 'message private';
   const time = new Date(ts).toLocaleTimeString();
   if (currentUser && from.id === currentUser.id) {
-    div.innerHTML = `<span class="author">To ${to.name}</span>: ${escapeHtml(text)} <span class="time">${time}</span>`;
+    div.innerHTML = `<span class="author">You:</span> ${escapeHtml(text)} <span class="time">${time}</span>`;
   } else {
-    div.innerHTML = `<span class="author">From ${from.name}</span>: ${escapeHtml(text)} <span class="time">${time}</span>`;
+    div.innerHTML = `<span class="author">${escapeHtml(from.name)}:</span> ${escapeHtml(text)} <span class="time">${time}</span>`;
   }
-  messagesEl.appendChild(div);
-  messagesEl.scrollTop = messagesEl.scrollHeight;
+  list.appendChild(div);
+  list.scrollTop = list.scrollHeight;
 }
 
 // Prefill two options on load

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
       <div class="hint">Up to 10 users can join.</div>
     </section>
 
-    <section id="chatSection" class="hidden">
+      <section id="chatSection" class="hidden">
       <div class="left-pane">
         <h3>Users <small>(click name for PM)</small></h3>
         <ul id="userList"></ul>
@@ -51,8 +51,9 @@
           <div id="pollList"></div>
         </div>
       </div>
-    </section>
-  </div>
-  <script src="client.js"></script>
-</body>
-</html>
+      </section>
+      <div id="privateChats"></div>
+    </div>
+    <script src="client.js"></script>
+  </body>
+  </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -52,3 +52,60 @@ h1 { font-size: 18px; margin: 0; }
 .poll .meta { color: #666; font-size: 12px; margin-bottom: 6px; }
 .poll .options { display: flex; flex-direction: column; gap: 6px; }
 .poll .options .vote { text-align: left; padding: 8px; border: 1px solid #ddd; background: #f9fafb; border-radius: 8px; cursor: pointer; }
+
+#privateChats {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  display: flex;
+  gap: 8px;
+}
+
+.private-chat {
+  width: 220px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.private-chat .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 6px;
+  background: #f3f4f6;
+  border-bottom: 1px solid #ddd;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.private-chat .messages {
+  flex: 1;
+  padding: 4px;
+  overflow-y: auto;
+  height: 160px;
+}
+
+.private-chat .composer {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border-top: 1px solid #eee;
+}
+
+.private-chat .composer input {
+  flex: 1;
+  padding: 4px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.private-chat .composer button {
+  padding: 4px 6px;
+  border: 1px solid #ddd;
+  background: #fafafa;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- open dedicated private chat windows when clicking a user
- style and manage private chat panels
- render direct messages in their own windows

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a08ce3248c8326ba8f511d0259909b